### PR TITLE
Fix error when searching for the id of a non-existent proxy

### DIFF
--- a/src/backends/supercollider.lisp
+++ b/src/backends/supercollider.lisp
@@ -39,7 +39,8 @@
   "Get the current node ID of the proxy NAME, or NIL if it doesn't exist in cl-collider's node-proxy-table."
   (if (typep name 'sc::node)
       (get-proxys-node-id (alexandria:make-keyword (string-upcase (slot-value name 'sc::name))))
-      (sc::id (gethash name (sc::node-proxy-table sc::*s*)))))
+      (alexandria:when-let ((val (gethash name (sc::node-proxy-table sc::*s*))))
+	(sc::id val))))
 
 (defgeneric supercollider-convert-object (object key)
   (:documentation "Method used to convert objects in events to values the SuperCollider server can understand. For example, any `cl-collider::buffer' objects are converted to their bufnum."))


### PR DESCRIPTION
Instead of the error, `get-proxys-node-id` should return NIL, as per
the docstring.