### PR TITLE
midi backend: add pitchbend

### DIFF
--- a/src/backends/alsa-midi.lisp
+++ b/src/backends/alsa-midi.lisp
@@ -1,6 +1,4 @@
 ;;;; alsa-midi.lisp - backend to output MIDI via ALSA.
-;; FIX: add bend?
-;; FIX: allow non-midinote frequencies to be sent as midinote+midi detune (i.e. auto-convert :freq to those keys when enabled)
 
 (in-package #:cl-patterns)
 
@@ -16,6 +14,19 @@
         (dolist (note (iota 128))
           (midihelper:send-event (midihelper:ev-noteoff c note 0)))
         (midihelper:send-event (midihelper:ev-cc c 123 0)))))
+
+;;; pitch bending
+
+(defvar *alsa-midi-pitchbend-range* 2
+  "Number of semitones in the pitchbend range of the MIDI device.")
+
+(defun midi-pitchbend (bend midinote)
+  "Return a pitchbend MIDI value, given BEND, on a range of -1.0..1.0, and MIDINOTE. If BEND is non-nil, convert it to the appropriate number for the MIDI message. Otherwise, if MIDINOTE has a decimal part, return the amount of pitchbend necessary to detune it. This allows for microtonality to be expressed as a fraction of a midinote, or auto-converted from the :freq event key. If both BEND and a fractional MIDINOTE are given, only BEND is considered."
+  (cond (bend (bipolar-1-to-midi-pitchbend bend))
+	(midinote (let ((decimal (mod midinote 1)))
+		    (unless (zerop decimal)
+		      (bipolar-1-to-midi-pitchbend
+		       (/ decimal *alsa-midi-pitchbend-range*)))))))
 
 ;;; instrument mapping
 
@@ -188,6 +199,8 @@ See also: `alsa-midi-instrument-program-number'"
                                            15))
              (note (midi-truncate-clamp (event-value event :midinote)))
              (velocity (unipolar-1-to-midi (event-value event :amp))) ; FIX: maybe this shouldn't be linear?
+	     (bend (midi-pitchbend (event-value event :bend)
+				   (event-value event :midinote)))
              (time (or (raw-event-value event :timestamp-at-start) (local-time:now)))
              (extra-params (loop :for key :in (keys event)
                                  :for cc-mapping := (alsa-midi-remap-key-value key (event-value event key))
@@ -202,6 +215,8 @@ See also: `alsa-midi-instrument-program-number'"
              (setf (nth channel *alsa-midi-channels-instruments*) pgm))
            (dolist (param extra-params)
              (midihelper:send-event (midihelper:ev-cc channel (first param) (second param))))
+	   (when bend
+	     (midihelper:send-event (midihelper:ev-pitchbend channel bend)))
            (unless (eql type :set)
              (midihelper:send-event (midihelper:ev-noteon channel note velocity))
              (sleep (max 0 (dur-time (sustain event) (tempo (task-clock task)))))
@@ -212,4 +227,4 @@ See also: `alsa-midi-instrument-program-number'"
   ;; FIX
   )
 
-(export '(alsa-midi-panic alsa-midi-instrument-program-number alsa-midi-cc-mapping alsa-midi-set-cc-mapping alsa-midi-remap-key-value))
+(export '(alsa-midi-panic *alsa-midi-pitchbend-range* alsa-midi-instrument-program-number alsa-midi-cc-mapping alsa-midi-set-cc-mapping alsa-midi-remap-key-value))

--- a/src/conversions.lisp
+++ b/src/conversions.lisp
@@ -369,3 +369,7 @@ See also: `parse-boolean'"
     (integer boolean)
     (rational (if (>= boolean 0.5) 127 0))
     (boolean (if boolean 127 0))))
+
+(defconversion bipolar-1-to-midi-pitchbend (number)
+  "Convert the range -1..1 to pitchbend message values used by the `alsa-midi' backend."
+  (clamp (ceiling (* 8192 number)) -8192 8191))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -104,6 +104,7 @@
    #:bipolar-1-to-midi
    #:unipolar-1-to-midi
    #:frequency-to-midi
+   #:bipolar-1-to-midi-pitchbend
 
    ;;; scales.lisp
 


### PR DESCRIPTION
Adds the `:bend` key in the context of the alsa-midi backend.
:bend accepts values from -1 to +1. How these values translate into semitones varies widely according to each specific midi device.

This PR depends on [this cl-alsaseq update](https://github.com/defaultxr/cl-alsaseq/pull/4/commits).

To test:

``` lisp
;; Simultaneous note and pitchbend
(pb :detune/microtones
  :instrument 0
  :midinote 60
  :bend (pseq (list (pseries 0 -.1 10) (pseries 0 .1 10)))
  :dur 1/4)

(play :detune/microtones)

;; Play a key and adjust the pitch wheel afterwards
(pb :c
  :type :note
  :instrument 0
  :midinote 60
  :dur 2)

(pb :pitchbend
  :type :set
  :instrument 0
  :dur 1
  :bend (pseq (list 0 (pwhite -1.0 1.0 1))))

(play (ppar '(:c :pitchbend)))
```